### PR TITLE
Add fractional ODE KAN example

### DIFF
--- a/scripts/fractional_ode_kan.py
+++ b/scripts/fractional_ode_kan.py
@@ -1,17 +1,16 @@
-"""Solve a fractional ODE using KAN and derive a symbolic form.
+"""Solve a fractional ODE using KAN and expose a symbolic formula.
 
-This script trains a simple 1D Kolmogorov--Arnold Network on a fractional
-ordinary differential equation (ODE).  After fitting the network we call
-``auto_symbolic`` to convert the learned splines to closed form symbolic
-expressions and continue training with those expressions fixed.
-
-The default equation solved here is
+This demo is inspired by the notebook examples in ``tutorials/Example`` and
+illustrates several advantages of Kolmogorov--Arnold Networks: a small network
+can accurately solve a differential equation, the grid can be refined for higher
+precision, and the learned activation functions can be automatically converted to
+closed-form expressions.  We solve the fractional ODE
 
 .. math:: \partial_t^\alpha u + u = f(t), \qquad u(0)=0,
 
-with an analytic solution :math:`u(t)=t^{5+\alpha}` when
-``f`` is chosen appropriately.  The order ``alpha`` as well as the time
-grid can be changed from the command line.
+whose analytic solution is :math:`u(t)=t^{5+\alpha}` for a suitable forcing
+``f``.  The order ``alpha`` as well as the grid resolution can be changed from
+the command line.
 """
 
 import argparse
@@ -81,19 +80,51 @@ def main():
         default=200,
         help="additional steps after auto_symbolic",
     )
+    parser.add_argument("--grid", type=int, default=5, help="initial grid size")
+    parser.add_argument(
+        "--refine",
+        type=int,
+        default=0,
+        help="refine to this grid after the first training phase (0 to skip)",
+    )
+    parser.add_argument(
+        "--hidden",
+        type=int,
+        default=1,
+        help="number of hidden neurons",
+    )
+    parser.add_argument(
+        "--prune",
+        action="store_true",
+        help="prune the network after auto_symbolic",
+    )
     args = parser.parse_args()
 
     tau = args.T / args.nt
     t = torch.linspace(0, args.T, steps=args.nt).view(-1, 1)
 
-    model = KAN(width=[1, 1], grid=5, k=3, grid_eps=1.0, noise_scale_base=0.25)
+    width = [1, args.hidden, 1]
+    model = KAN(width=width, grid=args.grid, k=3, grid_eps=1.0, noise_scale_base=0.25)
     model.speed()  # disable symbolic bookkeeping during the numeric phase
 
     train(model, t, tau, args.alpha, args.nt, steps=args.steps)
 
+    # optional grid refinement
+    if args.refine and args.refine != args.grid:
+        model.save_act = True
+        model.get_act(t)
+        model = model.refine(args.refine)
+        model.speed()
+        train(model, t, tau, args.alpha, args.nt, steps=args.steps)
+
     # switch on symbolic branch and search for analytic forms
     model.symbolic_enabled = True
     model.auto_symbolic()
+
+    # optional pruning to promote interpretability
+    if args.prune:
+        model.get_act(t)
+        model = model.prune()
 
     # fine tune with symbolic edges fixed
     train(model, t, tau, args.alpha, args.nt, steps=args.symbolic_steps)

--- a/scripts/fractional_ode_kan.py
+++ b/scripts/fractional_ode_kan.py
@@ -1,0 +1,77 @@
+import torch
+from kan import KAN, LBFGS
+from tqdm import tqdm
+import matplotlib.pyplot as plt
+
+# Parameters
+T = 1.4
+nt = 20
+alpha = 0.5
+tau = T/nt
+
+def a(l, alpha):
+    return (l + 1)**(1 - alpha) - l**(1 - alpha)
+
+# forcing term f(t)
+def f(t, alpha):
+    gamma_part = torch.lgamma(torch.tensor(6 + alpha)).exp() / 120
+    return gamma_part * t**5 + t**(5 + alpha)
+
+# build training points
+t = torch.linspace(0, T, steps=nt).view(-1, 1)
+
+# create KAN model
+model = KAN(width=[1, 1], grid=5, k=3, grid_eps=1.0, noise_scale_base=0.25)
+model.speed()  # disable slow symbolic bookkeeping during training
+
+# loss for fractional ODE
+def loss_fn(model, t, tau, alpha):
+    u_pred = model(t).view(-1)
+    u0 = torch.tensor(0.0)
+    ic_loss = (u_pred[0] - u0)**2
+    eq_loss = 0.0
+    for n in range(1, nt):
+        t_n = t[n]
+        history = sum((a(n - k - 1, alpha) - a(n - k, alpha)) * u_pred[k] for k in range(1, n))
+        D_alpha_u = tau**-alpha / torch.lgamma(torch.tensor(2 - alpha)).exp() * (
+            u_pred[n] * a(0, alpha) - history - a(n - 1, alpha) * u0)
+        eq_loss += (D_alpha_u + u_pred[n] - f(t_n, alpha))**2
+    return ic_loss + eq_loss
+
+# training loop
+def train(model, steps=500, log=100):
+    opt = LBFGS(model.parameters(), lr=0.1, history_size=10, line_search_fn="strong_wolfe")
+    pbar = tqdm(range(steps), desc="train")
+    for i in pbar:
+        def closure():
+            opt.zero_grad()
+            loss = loss_fn(model, t, tau, alpha)
+            loss.backward()
+            return loss
+        opt.step(closure)
+        if i % log == 0:
+            with torch.no_grad():
+                l = loss_fn(model, t, tau, alpha)
+            pbar.set_description(f"loss={l.item():.2e}")
+
+if __name__ == "__main__":
+    train(model)
+    # enable symbolic functions and run automatic symbolic regression
+    model.symbolic_enabled = True
+    model.auto_symbolic()
+    # retrain with symbolic edges fixed
+    train(model, steps=200)
+    formulas, _ = model.symbolic_formula()
+    print("Symbolic formula:")
+    for idx, expr in enumerate(formulas[0]):
+        print(f"u_{idx} = {expr}")
+
+    # visualize prediction
+    t_test = torch.linspace(0, T, steps=100).view(-1,1)
+    u_pred = model(t_test).detach().numpy()
+    u_true = t_test.numpy()**(5 + alpha)
+    plt.plot(t_test, u_pred, label="Pred")
+    plt.plot(t_test, u_true, '--', label="True")
+    plt.xlabel('t'); plt.ylabel('u(t)')
+    plt.legend()
+    plt.show()

--- a/scripts/fractional_ode_kan.py
+++ b/scripts/fractional_ode_kan.py
@@ -1,77 +1,119 @@
+"""Solve a fractional ODE using KAN and derive a symbolic form.
+
+This script trains a simple 1D Kolmogorov--Arnold Network on a fractional
+ordinary differential equation (ODE).  After fitting the network we call
+``auto_symbolic`` to convert the learned splines to closed form symbolic
+expressions and continue training with those expressions fixed.
+
+The default equation solved here is
+
+.. math:: \partial_t^\alpha u + u = f(t), \qquad u(0)=0,
+
+with an analytic solution :math:`u(t)=t^{5+\alpha}` when
+``f`` is chosen appropriately.  The order ``alpha`` as well as the time
+grid can be changed from the command line.
+"""
+
+import argparse
 import torch
 from kan import KAN, LBFGS
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 
-# Parameters
-T = 1.4
-nt = 20
-alpha = 0.5
-tau = T/nt
 
 def a(l, alpha):
-    return (l + 1)**(1 - alpha) - l**(1 - alpha)
+    """Coefficient helper used in the Grunwald approximation."""
+    return (l + 1) ** (1 - alpha) - l ** (1 - alpha)
 
-# forcing term f(t)
-def f(t, alpha):
+
+def forcing(t, alpha):
+    """Right-hand side ``f(t)`` yielding ``u(t)=t**(5+alpha)``."""
     gamma_part = torch.lgamma(torch.tensor(6 + alpha)).exp() / 120
-    return gamma_part * t**5 + t**(5 + alpha)
+    return gamma_part * t ** 5 + t ** (5 + alpha)
 
-# build training points
-t = torch.linspace(0, T, steps=nt).view(-1, 1)
 
-# create KAN model
-model = KAN(width=[1, 1], grid=5, k=3, grid_eps=1.0, noise_scale_base=0.25)
-model.speed()  # disable slow symbolic bookkeeping during training
-
-# loss for fractional ODE
-def loss_fn(model, t, tau, alpha):
+def loss_fn(model, t, tau, alpha, nt):
+    """Compute the fractional ODE residual loss."""
     u_pred = model(t).view(-1)
     u0 = torch.tensor(0.0)
-    ic_loss = (u_pred[0] - u0)**2
+
+    ic_loss = (u_pred[0] - u0) ** 2
     eq_loss = 0.0
     for n in range(1, nt):
         t_n = t[n]
-        history = sum((a(n - k - 1, alpha) - a(n - k, alpha)) * u_pred[k] for k in range(1, n))
-        D_alpha_u = tau**-alpha / torch.lgamma(torch.tensor(2 - alpha)).exp() * (
-            u_pred[n] * a(0, alpha) - history - a(n - 1, alpha) * u0)
-        eq_loss += (D_alpha_u + u_pred[n] - f(t_n, alpha))**2
+        k = torch.arange(1, n)
+        history = torch.sum(
+            (a(n - k - 1, alpha) - a(n - k, alpha)) * u_pred[k]
+        )
+        coeff = tau ** -alpha / torch.lgamma(torch.tensor(2 - alpha)).exp()
+        d_alpha_u = coeff * (u_pred[n] * a(0, alpha) - history - a(n - 1, alpha) * u0)
+        eq_loss += (d_alpha_u + u_pred[n] - forcing(t_n, alpha)) ** 2
     return ic_loss + eq_loss
 
-# training loop
-def train(model, steps=500, log=100):
+
+def train(model, t, tau, alpha, nt, steps=500, log=100):
+    """Minimal LBFGS training loop."""
     opt = LBFGS(model.parameters(), lr=0.1, history_size=10, line_search_fn="strong_wolfe")
     pbar = tqdm(range(steps), desc="train")
     for i in pbar:
         def closure():
             opt.zero_grad()
-            loss = loss_fn(model, t, tau, alpha)
+            loss = loss_fn(model, t, tau, alpha, nt)
             loss.backward()
             return loss
+
         opt.step(closure)
         if i % log == 0:
             with torch.no_grad():
-                l = loss_fn(model, t, tau, alpha)
+                l = loss_fn(model, t, tau, alpha, nt)
             pbar.set_description(f"loss={l.item():.2e}")
 
-if __name__ == "__main__":
-    train(model)
-    # enable symbolic functions and run automatic symbolic regression
+
+def main():
+    parser = argparse.ArgumentParser(description="Fractional ODE with KAN")
+    parser.add_argument("--T", type=float, default=1.4, help="end time")
+    parser.add_argument("--nt", type=int, default=20, help="number of time steps")
+    parser.add_argument("--alpha", type=float, default=0.5, help="fractional order")
+    parser.add_argument("--steps", type=int, default=500, help="training steps")
+    parser.add_argument(
+        "--symbolic_steps",
+        type=int,
+        default=200,
+        help="additional steps after auto_symbolic",
+    )
+    args = parser.parse_args()
+
+    tau = args.T / args.nt
+    t = torch.linspace(0, args.T, steps=args.nt).view(-1, 1)
+
+    model = KAN(width=[1, 1], grid=5, k=3, grid_eps=1.0, noise_scale_base=0.25)
+    model.speed()  # disable symbolic bookkeeping during the numeric phase
+
+    train(model, t, tau, args.alpha, args.nt, steps=args.steps)
+
+    # switch on symbolic branch and search for analytic forms
     model.symbolic_enabled = True
     model.auto_symbolic()
-    # retrain with symbolic edges fixed
-    train(model, steps=200)
+
+    # fine tune with symbolic edges fixed
+    train(model, t, tau, args.alpha, args.nt, steps=args.symbolic_steps)
+
     formulas, _ = model.symbolic_formula()
     print("Symbolic formula:")
-    for idx, expr in enumerate(formulas[0]):
-        print(f"u_{idx} = {expr}")
+    for i, expr in enumerate(formulas[0]):
+        print(f"u_{i} = {expr}")
 
-    # visualize prediction
-    t_test = torch.linspace(0, T, steps=100).view(-1,1)
+    # plot prediction against the analytic solution
+    t_test = torch.linspace(0, args.T, steps=100).view(-1, 1)
     u_pred = model(t_test).detach().numpy()
-    u_true = t_test.numpy()**(5 + alpha)
+    u_true = t_test.numpy() ** (5 + args.alpha)
     plt.plot(t_test, u_pred, label="Pred")
-    plt.plot(t_test, u_true, '--', label="True")
-    plt.xlabel('t'); plt.ylabel('u(t)')
+    plt.plot(t_test, u_true, "--", label="True")
+    plt.xlabel("t")
+    plt.ylabel("u(t)")
     plt.legend()
     plt.show()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a new script demonstrating how to use KAN for solving a fractional ODE
- automatically converts edges to symbolic functions via `auto_symbolic`

## Testing
- `python -m py_compile scripts/fractional_ode_kan.py`

------
https://chatgpt.com/codex/tasks/task_e_6848e74728ec8328af8638bbe1b15fdf